### PR TITLE
Move from Ubuntu to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM ubuntu:16.04
+FROM frolvlad/alpine-glibc:alpine-3.4
 
-MAINTAINER alex.devalx@gmail.com
+MAINTAINER BastiOfBerlin
 
 ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.0.13.4/teamspeak3-server_linux_amd64-3.0.13.4.tar.bz2
 ENV TS3_UID 1000
 
-RUN apt-get update -q \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -qy bzip2 wget \
-  && apt-get clean \
-  && rm -rf /var/lib/apt \
-  && useradd -u ${TS3_UID} ts3 \
+RUN adduser -S -D -u ${TS3_UID} ts3 \
   && mkdir -p /home/ts3 \
   && wget -q -O /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 ${TEAMSPEAK_URL} \
   && tar --directory /home/ts3 -xjf /home/ts3/teamspeak3-server_linux_amd64.tar.bz2 \

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ If your host uses SELinux it may be necessary to use the **:z** option:
 ```
 docker run --name ts3 -d -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v /data/teamspeak:/home/ts3/data:z devalx/docker-teamspeak3:latest
 ```
-Also see issue [devalx/docker-teamspeak3#6]
+Also see issue [https://github.com/devalx/docker-teamspeak3/issues/6]

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ If your host uses SELinux it may be necessary to use the **:z** option:
 ```
 docker run --name ts3 -d -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v /data/teamspeak:/home/ts3/data:z devalx/docker-teamspeak3:latest
 ```
-Also see issue [#6](../../issues/6)
+Also see issue devalx/docker-teamspeak3#6

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ If your host uses SELinux it may be necessary to use the **:z** option:
 ```
 docker run --name ts3 -d -p 9987:9987/udp -p 30033:30033 -p 10011:10011 -v /data/teamspeak:/home/ts3/data:z devalx/docker-teamspeak3:latest
 ```
-Also see issue devalx/docker-teamspeak3#6
+Also see issue [devalx/docker-teamspeak3#6]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## docker-teamspeak3
 
-Ubuntu with TS3 Server.
+Alpine+glibc with TS3 Server.
 
 ### Summary
-* Ubuntu + Teamspeak 3 Server
+* Alpine+glibc + Teamspeak 3 Server
 * Some files can be injected to host:
   * query_ip_whitelist.txt
   * query_ip_blacklist.txt


### PR DESCRIPTION
Using Alpine + glibc now (from [frol/docker-alpine-glibc](https://github.com/frol/docker-alpine-glibc)).
Image size decreased from 148.6M to 25.1M.